### PR TITLE
Add PHP 8 compatibility and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'claude/**'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    name: PHP ${{ matrix.php }} lint
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['5.6', '7.4', '8.0', '8.1', '8.2', '8.3']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Parallel lint
+        run: vendor/bin/parallel-lint --exclude vendor .

--- a/HTML/QuickForm/depselect.php
+++ b/HTML/QuickForm/depselect.php
@@ -2,15 +2,23 @@
 require_once 'HTML/QuickForm/text.php';
 
 class HTML_QuickForm_depselect extends HTML_QuickForm_text {
-    
-    function HTML_QuickForm_depselect(
-            $elementName=null, 
-            $elementLabel=null, 
-            $attributes=null, 
+
+    function __construct(
+            $elementName=null,
+            $elementLabel=null,
+            $attributes=null,
             $properties=null){
-        parent::HTML_QuickForm_input($elementName, $elementLabel, $attributes);
+        // PHP 4-style parent constructors are fatal in PHP 8. Prefer
+        // parent::__construct(), but fall back to the PHP 4 ctor name
+        // for installations running against pre-modernized PEAR
+        // HTML_QuickForm bundles shipped with older xataface versions.
+        if (is_callable(array('HTML_QuickForm_input', '__construct'))) {
+            parent::__construct($elementName, $elementLabel, $attributes);
+        } else {
+            parent::HTML_QuickForm_input($elementName, $elementLabel, $attributes);
+        }
     }
-    
+
     function toHtml(){
         $oldFrozen = $this->_flagFrozen;
         $this->_flagFrozen = 0;
@@ -23,4 +31,3 @@ class HTML_QuickForm_depselect extends HTML_QuickForm_text {
         return $out;
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "shannah/xataface-module-depselect",
+    "description": "Xataface dependent-select widget module.",
+    "type": "xataface-module",
+    "license": "LGPL-2.1-or-later",
+    "require": {
+        "php": ">=5.6"
+    },
+    "require-dev": {
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "phpstan/phpstan": "^1.10"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpstan/phpstan": "^1.10"
+        "php-parallel-lint/php-parallel-lint": "^1.3"
     }
 }


### PR DESCRIPTION
## Summary
This PR modernizes the `HTML_QuickForm_depselect` class for PHP 8 compatibility while maintaining backward compatibility with PHP 5.6+, and adds CI infrastructure.

## Key Changes
- **PHP 8 Compatibility**: Converted PHP 4-style constructor to `__construct()` method with fallback logic for older PEAR HTML_QuickForm versions that haven't been modernized
- **Constructor Compatibility**: Added runtime check to use `parent::__construct()` when available, falling back to PHP 4-style parent constructor call for legacy installations
- **Code Cleanup**: Fixed whitespace inconsistencies (trailing spaces, blank lines)
- **CI/CD Setup**: Added GitHub Actions workflow to lint code against PHP 5.6, 7.4, 8.0, 8.1, 8.2, and 8.3
- **Project Configuration**: Added `composer.json` with project metadata and dev dependencies for linting

## Implementation Details
The constructor change uses a conditional check at runtime to determine which parent constructor calling convention to use. This ensures the module works with both modernized PEAR bundles (PHP 8+) and legacy xataface installations that ship older, unmodified PEAR versions.

https://claude.ai/code/session_016DCo77UGqTpHnRw9RG6eGz